### PR TITLE
Make print compatible with python2 and python3; add requirements.txt …

### DIFF
--- a/oauth2/api_access_application_authentication.py
+++ b/oauth2/api_access_application_authentication.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from __future__ import print_function
 import json
 
 from oauth2client.client import GoogleCredentials
@@ -41,7 +41,7 @@ def main():
     content = gcs_service.objects().list(
         bucket='lunchmates_document_dropbox').execute()
 
-    print json.dumps(content)
+    print(json.dumps(content))
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+apiclient==1.0.2
+google-api-python-client==1.4.2
+httplib2==0.9.1
+oauth2client==1.5.1
+pyasn1==0.1.8
+pyasn1-modules==0.0.7
+rsa==3.2
+simplejson==3.8.0
+six==1.9.0
+uritemplate==0.6
+urllib3==1.12


### PR DESCRIPTION
…for easy installation of dependencies. Note that the requirements have versions that are compatible with python3. No effort was made to ensure that the requirements.txt was minimal.
